### PR TITLE
Remove unnecessary variable.

### DIFF
--- a/templates/quickstart-cisco-meraki-sdwan-vmx-tgw.yaml
+++ b/templates/quickstart-cisco-meraki-sdwan-vmx-tgw.yaml
@@ -211,7 +211,6 @@ Resources:
       MemorySize: 3008
       Environment:
         Variables:
-          MERAKI_API_KEY: !Ref 'MerakiAPIKey'
           MERAKI_ORG_ID: !Ref 'MerakiOrgID'
           TGW_RT_ID: !Ref 'TransitGatewaySDWANRouteTable'
           TGW_ATTACH_ID: !Ref 'TransitGatewayAttachment'


### PR DESCRIPTION
Remove the Meraki Dashboard API Key variable from the AWS Lambda environment variable.
Meraki Dashboard API Key is stored in AWS Secrets Manager.

*Issue: #26*