### PR TITLE
Fix reference to MerakiApiKey camel casing fix

### DIFF
--- a/functions/source/lambda_function.py
+++ b/functions/source/lambda_function.py
@@ -22,8 +22,10 @@ RT_ID = os.environ['RT_ID']
 VMX1_TAG = os.environ['vMX1Tag']
 VMX2_TAG = os.environ['vMX2Tag']
 
+# No security needed on seret_name as this is not a password but a refference to the secret in secrets manager.
+#
 def get_meraki_key():
-    secret_name = 'MerakiAPIKey'
+    secret_name = 'MerakiAPIKey' #nosec
     region = os.environ['AWS_REGION']
     session = boto3.session.Session()
     client = session.client(
@@ -46,7 +48,7 @@ def get_meraki_key():
         # Depending on whether the secret was a string or binary, only one of these fields will be populated
         if 'SecretString' in get_secret_value_response:
             text_secret_data = json.loads(get_secret_value_response['SecretString'])
-            merakiapikey = text_secret_data['MerakiApiKey'] #nosec
+            merakiapikey = text_secret_data['MerakiApiKey']
             return merakiapikey
         else:
             binary_secret_data = get_secret_value_response['SecretBinary']

--- a/functions/source/lambda_function.py
+++ b/functions/source/lambda_function.py
@@ -46,7 +46,7 @@ def get_meraki_key():
         # Depending on whether the secret was a string or binary, only one of these fields will be populated
         if 'SecretString' in get_secret_value_response:
             text_secret_data = json.loads(get_secret_value_response['SecretString'])
-            merakiapikey = text_secret_data['MerakiApiKey']
+            merakiapikey = text_secret_data['MerakiApiKey'] #nosec
             return merakiapikey
         else:
             binary_secret_data = get_secret_value_response['SecretBinary']

--- a/functions/source/lambda_function.py
+++ b/functions/source/lambda_function.py
@@ -46,7 +46,7 @@ def get_meraki_key():
         # Depending on whether the secret was a string or binary, only one of these fields will be populated
         if 'SecretString' in get_secret_value_response:
             text_secret_data = json.loads(get_secret_value_response['SecretString'])
-            merakiapikey = text_secret_data['merakiapikey']
+            merakiapikey = text_secret_data['MerakiApiKey']
             return merakiapikey
         else:
             binary_secret_data = get_secret_value_response['SecretBinary']


### PR DESCRIPTION
This previously would cause no definition error in lambda.

*Issue #, if available:*

*Description of changes:

Updating camel casing to reduce definition errors from lambda.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
